### PR TITLE
Make get-version.sh work with current minecraft.azureedge.net

### DIFF
--- a/files/get-version.sh
+++ b/files/get-version.sh
@@ -3,7 +3,7 @@
 reUrl='https://minecraft.azureedge.net/bin-linux/bedrock-server-(.*?).zip'
 reVersion='(([0-9]+.?)+)'
 
-data=$(curl -sL https://www.minecraft.net/en-us/download/server/bedrock/)
+data=$(curl -H "user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36" -sL https://www.minecraft.net/en-us/download/server/bedrock/)
 url=$(echo $data | grep -ioE $reUrl)
 
 version=$(echo $url | grep -ioE $reVersion)


### PR DESCRIPTION
It seems that minecraft.azureedge.net server rejects plain curl requests (with HTTP 403 error code),
so let's pretend we are regular browser so that we get page content which contains version number.

Before this fix I got following error:
```
$ curl -sL https://www.minecraft.net/en-us/download/server/bedrock/
<HTML><HEAD>
<TITLE>Access Denied</TITLE>
</HEAD><BODY>
<H1>Access Denied</H1>

You don't have permission to access "http&#58;&#47;&#47;www&#46;minecraft&#46;net&#47;en&#45;us&#47;download&#47;server&#47;bedrock&#47;" on this server.<P>
Reference&#32;&#35;18&#46;15e17b5c&#46;1633501288&#46;a237ca0
</BODY>
</HTML>
```