### PR TITLE
converting '-' to '_' in remco template

### DIFF
--- a/remco/templates/server.properties
+++ b/remco/templates/server.properties
@@ -1,4 +1,4 @@
-server-name={{ getv("/minecraft/server-name", "world") }}
+server-name={{ getv("/minecraft/server/name", "world") }}
 # Used as the server name
 # Allowed values: Any string
 
@@ -10,59 +10,59 @@ difficulty={{ getv("/minecraft/difficulty", "normal") }}
 # Sets the difficulty of the world.
 # Allowed values: "peaceful", "easy", "normal", or "hard"
 
-allow-cheats={{ getv("/minecraft/allow-cheats", "true") }}
+allow-cheats={{ getv("/minecraft/allow/cheats", "true") }}
 # If true then cheats like commands can be used.
 # Allowed values: "true" or "false"
 
-max-players={{ getv("/minecraft/max-players", "20") }}
+max-players={{ getv("/minecraft/max/players", "20") }}
 # The maximum number of players that can play on the server.
 # Allowed values: Any positive integer
 
-online-mode={{ getv("/minecraft/online-mode", "false") }}
+online-mode={{ getv("/minecraft/online/mode", "false") }}
 # If true then all connected players must be authenticated to Xbox Live.
 # Clients connecting to remote (non-LAN) servers will always require Xbox Live authentication regardless of this setting.
 # If the server accepts connections from the Internet, then it's highly recommended to enable online-mode.
 # Allowed values: "true" or "false"
 
-white-list={{ getv("/minecraft/white-list", "false") }}
+white-list={{ getv("/minecraft/white/list", "false") }}
 # If true then all connected players must be listed in the separate whitelist.json file.
 # Allowed values: "true" or "false"
 
-server-port={{ getv("/minecraft/server-port", "19132") }}
+server-port={{ getv("/minecraft/server/port", "19132") }}
 # Which IPv4 port the server should listen to.
 # Allowed values: Integers in the range [1, 65535]
 
-server-portv6={{ getv("/minecraft/server-portv6", "19133") }}
+server-portv6={{ getv("/minecraft/server/portv6", "19133") }}
 # Which IPv6 port the server should listen to.
 # Allowed values: Integers in the range [1, 65535]
 
-view-distance={{ getv("/minecraft/view-distance", "10") }}
+view-distance={{ getv("/minecraft/view/distance", "10") }}
 # The maximum allowed view distance in number of chunks.
 # Allowed values: Any positive integer.
 
-tick-distance={{ getv("/minecraft/tick-distance", "4") }}
+tick-distance={{ getv("/minecraft/tick/distance", "4") }}
 # The world will be ticked this many chunks away from any player.
 # Allowed values: Integers in the range [4, 12]
 
-player-idle-timeout={{ getv("/minecraft/player-idle-timeout", "30") }}
+player-idle-timeout={{ getv("/minecraft/player/idle/timeout", "30") }}
 # After a player has idled for this many minutes they will be kicked. If set to 0 then players can idle indefinitely.
 # Allowed values: Any non-negative integer.
 
-max-threads={{ getv("/minecraft/max-threads", "8") }}
+max-threads={{ getv("/minecraft/max/threads", "8") }}
 # Maximum number of threads the server will try to use. If set to 0 or removed then it will use as many as possible.
 # Allowed values: Any positive integer.
 
-level-name={{ getv("/minecraft/level-name", "level") }}
+level-name={{ getv("/minecraft/level/name", "level") }}
 # Allowed values: Any string
 
-level-seed={{ getv("/minecraft/level-seed", "") }}
+level-seed={{ getv("/minecraft/level/seed", "") }}
 # Use to randomize the world
 # Allowed values: Any string
 
-default-player-permission-level={{ getv("/minecraft/default-player-permission-level", "member") }}
+default-player-permission-level={{ getv("/minecraft/default/player/permission/level", "member") }}
 # Permission level for new players joining for the first time.
 # Allowed values: "visitor", "member", "operator"
 
-texturepack-required={{ getv("/minecraft/texturepack-required", "false") }}
+texturepack-required={{ getv("/minecraft/texturepack/required", "false") }}
 # Force clients to use texture packs in the current world
 # Allowed values: "true" or "false"


### PR DESCRIPTION
For cloud service support that doesn't allow dashes in the environment variables. Converting all dashes to underscores as per best practice.